### PR TITLE
Added database server variable to connection details.

### DIFF
--- a/includes/helpers/Database Management/FFXIPH_DatabaseConnection.php
+++ b/includes/helpers/Database Management/FFXIPH_DatabaseConnection.php
@@ -3,21 +3,23 @@
 use Wikimedia\Rdbms\DatabaseFactory;
 
 class DatabaseConnection {
-
-	private $dbUsername;  
-	private $dbPassword;
+    private $dbServer;
+    private $dbUsername;
+    private $dbPassword;
 
     public function __construct() {
+        global $wgDBserver;
         global $wgDBuser;
         global $wgDBpassword;
 
+        $this->dbServer = $wgDBserver;
         $this->dbUsername = $wgDBuser;
         $this->dbPassword = $wgDBpassword;
     }
 
     private function getDatabaseFactory(mixed $database = null): DatabaseMysqli{
         return ( new DatabaseFactory() )->create( 'mysql', [
-                'host' => 'localhost',
+                'host' => $this->dbServer,
                 'user' => $this->dbUsername,
                 'password' => $this->dbPassword,
                 'dbname' => $database,
@@ -27,14 +29,11 @@ class DatabaseConnection {
 
     public function openConnection(mixed $dbName = null): mixed{
         try {
-            $returnDB = $this->getDatabaseFactory($dbName);            
+            $returnDB = $this->getDatabaseFactory($dbName);
         } catch ( DBConnectionError $e ) {
             $status->fatal( 'config-connection-error', $e->getMessage() );
             return $status;
         }
         return $returnDB; 
     }
-
 }
-
-?>


### PR DESCRIPTION
Instead of having `localhost` hardcoded as the server address, we now pull from MediaWiki's configured database server.